### PR TITLE
[nrf fromtree] mgmt: mcumgr: grp: img_mgmt: Add optional mutex lock support

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -332,6 +332,15 @@ int img_mgmt_state_confirm(void);
  */
 int img_mgmt_vercmp(const struct image_version *a, const struct image_version *b);
 
+#if IS_ENABLED(CONFIG_MCUMGR_GRP_IMG_MUTEX)
+/*
+ * @brief	Will reset the image management state back to default (no ongoing upload),
+ *		requires that CONFIG_MCUMGR_GRP_IMG_MUTEX be enabled to allow for mutex
+ *		locking of the image management state object.
+ */
+void img_mgmt_reset_upload(void);
+#endif
+
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
 /*
  * @brief	Translate IMG mgmt group error code into MCUmgr error code

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -25,6 +25,7 @@ menuconfig MCUMGR_GRP_IMG
 if MCUMGR_GRP_IMG
 
 if HEAP_MEM_POOL_SIZE > 0
+
 config MCUMGR_GRP_IMG_USE_HEAP_FOR_FLASH_IMG_CONTEXT
 	bool "Use heap mem pool for flash image DFU context"
 	help
@@ -38,6 +39,7 @@ config MCUMGR_GRP_IMG_USE_HEAP_FOR_FLASH_IMG_CONTEXT
 	  to allocate this context or it will not be possible to perform DFU; it may also not be
 	  possible to allocate such context when heap is under pressure, due to application
 	  operation, an issue that should also be addressed within application.
+
 endif
 
 config MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER
@@ -111,6 +113,15 @@ config MCUMGR_GRP_IMG_STATUS_HOOKS
 	  This will enable DFU status hooks which can be checked by the application to monitor DFU
 	  uploads. Note that these are status checking only, to allow inspecting of a file upload
 	  or prevent it, CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK must be used.
+
+config MCUMGR_GRP_IMG_MUTEX
+	bool "Mutex locking"
+	help
+	  This will enable use of a mutex to lock the image group object access, preventing issues
+	  of concurrent thread (i.e. multiple transport) access. This option also makes the
+	  ``img_mgmt_reset_upload()`` function visible in the image management group header, which
+	  can be used by applications to reset the image management state (useful if there are
+	  multiple ways that firmware updates can be loaded).
 
 module = MCUMGR_GRP_IMG
 module-str = mcumgr_grp_img

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
@@ -134,6 +134,18 @@ int img_mgmt_erase_if_needed(uint32_t off, uint32_t len);
 int img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 			    struct img_mgmt_upload_action *action);
 
+/**
+ * @brief	Takes the image management lock (if enabled) to prevent other
+ *		threads interfering with an ongoing operation.
+ */
+void img_mgmt_take_lock(void);
+
+/**
+ * @brief	Releases the held image management lock (if enabled) to allow
+ *		other threads to use image management operations.
+ */
+void img_mgmt_release_lock(void);
+
 #define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
 int img_mgmt_erased_val(int slot, uint8_t *erased_val);
 

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -71,6 +71,10 @@ LOG_MODULE_REGISTER(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);
 
 struct img_mgmt_state g_img_mgmt_state;
 
+#ifdef CONFIG_MCUMGR_GRP_IMG_MUTEX
+static K_MUTEX_DEFINE(img_mgmt_mutex);
+#endif
+
 #ifdef CONFIG_MCUMGR_GRP_IMG_VERBOSE_ERR
 const char *img_mgmt_err_str_app_reject = "app reject";
 const char *img_mgmt_err_str_hdr_malformed = "header malformed";
@@ -82,6 +86,20 @@ const char *img_mgmt_err_str_flash_write_failed = "fa write fail";
 const char *img_mgmt_err_str_downgrade = "downgrade";
 const char *img_mgmt_err_str_image_bad_flash_addr = "img addr mismatch";
 #endif
+
+void img_mgmt_take_lock(void)
+{
+#ifdef CONFIG_MCUMGR_GRP_IMG_MUTEX
+	k_mutex_lock(&img_mgmt_mutex, K_FOREVER);
+#endif
+}
+
+void img_mgmt_release_lock(void)
+{
+#ifdef CONFIG_MCUMGR_GRP_IMG_MUTEX
+	k_mutex_unlock(&img_mgmt_mutex);
+#endif
+}
 
 /**
  * Finds the TLVs in the specified image slot, if any.
@@ -133,6 +151,7 @@ int img_mgmt_active_image(void)
 #endif
 	return 0;
 }
+
 /*
  * Reads the version and build hash from the specified image slot.
  */
@@ -281,10 +300,16 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
 /*
  * Resets upload status to defaults (no upload in progress)
  */
+#ifdef CONFIG_MCUMGR_GRP_IMG_MUTEX
 void img_mgmt_reset_upload(void)
+#else
+static void img_mgmt_reset_upload(void)
+#endif
 {
+	img_mgmt_take_lock();
 	memset(&g_img_mgmt_state, 0, sizeof(g_img_mgmt_state));
 	g_img_mgmt_state.area_id = -1;
+	img_mgmt_release_lock();
 }
 
 static int
@@ -330,6 +355,8 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 		return MGMT_ERR_EINVAL;
 	}
 
+	img_mgmt_take_lock();
+
 	/*
 	 * First check if image info is valid.
 	 * This check is done incase the flash area has a corrupted image.
@@ -363,11 +390,14 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 
 	if (IS_ENABLED(CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR)) {
 		if (!zcbor_tstr_put_lit(zse, "rc") || !zcbor_int32_put(zse, 0)) {
+			img_mgmt_release_lock();
 			return MGMT_ERR_EMSGSIZE;
 		}
 	}
 
 end:
+	img_mgmt_release_lock();
+
 	return MGMT_ERR_EOK;
 }
 
@@ -482,6 +512,8 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 		return MGMT_ERR_EINVAL;
 	}
 
+	img_mgmt_take_lock();
+
 	/* Determine what actions to take as a result of this request. */
 	rc = img_mgmt_upload_inspect(&req, &action);
 	if (rc != 0) {
@@ -500,7 +532,9 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 		/* Request specifies incorrect offset.  Respond with a success code and
 		 * the correct offset.
 		 */
-		return img_mgmt_upload_good_rsp(ctxt);
+		rc = img_mgmt_upload_good_rsp(ctxt);
+		img_mgmt_release_lock();
+		return rc;
 	}
 
 #if defined(CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK)
@@ -695,6 +729,8 @@ end:
 			img_mgmt_reset_upload();
 		}
 	}
+
+	img_mgmt_release_lock();
 
 	if (!ok) {
 		return MGMT_ERR_EMSGSIZE;


### PR DESCRIPTION
Adds an optional Kconfig that adds mutex locks to image management group functions, this prevents collision between multiple threads and/or transports.

Signed-off-by: Jamie McCrae <jamie.mccrae@nordicsemi.no>
(cherry picked from commit 0b6077443db7cdca6242f165f910b9e1721f5919)