### PR TITLE
[nrf fromtree] mgmt: mcumgr: smp: Allow preventing command execution …

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -474,7 +474,9 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 	bool data_match = false;
 #endif
 
-#if defined(CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK) || defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
+#if defined(CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK) ||	\
+defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS) ||		\
+defined(CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS)
 	enum mgmt_cb_return status;
 	int32_t ret_rc;
 	uint16_t ret_group;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -474,10 +474,13 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 	bool data_match = false;
 #endif
 
+#if defined(CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK)
+	enum mgmt_cb_return status;
+#endif
+
 #if defined(CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK) ||	\
 defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS) ||		\
 defined(CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS)
-	enum mgmt_cb_return status;
 	int32_t ret_rc;
 	uint16_t ret_group;
 #endif


### PR DESCRIPTION
…via hook

Adds status checking to the command status hook which allows an application to inspect a request and, optionally, reject it.

Signed-off-by: Jamie McCrae <jamie.mccrae@nordicsemi.no>
(cherry picked from commit 6877ad413f076d7aa48582a1877748b1cca13d5f)